### PR TITLE
fix/#16: OAuth2 로그인 및 사용자 정보 등록 기능 개선

### DIFF
--- a/src/main/java/com/app/pofolit_be/common/utils/RedisService.java
+++ b/src/main/java/com/app/pofolit_be/common/utils/RedisService.java
@@ -26,7 +26,7 @@ public class RedisService {
       return value;
    }
    public void setValuesWithTimeout(String key,String value,long timeout) {
-      redis.opsForValue().set(key, value, timeout, TimeUnit.MICROSECONDS);
+      redis.opsForValue().set(key, value, timeout, TimeUnit.SECONDS);
 
    }
    // del

--- a/src/main/java/com/app/pofolit_be/security/SecurityConfig.java
+++ b/src/main/java/com/app/pofolit_be/security/SecurityConfig.java
@@ -6,12 +6,19 @@ import com.app.pofolit_be.user.service.OAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Spring Security 설정 클래스
@@ -22,33 +29,58 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtFilter jwtFilter;
-    private final OAuth2UserService oAuth2UserService;
-    private final OAuth2AuthSuccessHandler oAuth2AuthSuccessHandler;
+   private final JwtFilter jwtFilter;
+   private final OAuth2UserService oAuth2UserService;
+   private final OAuth2AuthSuccessHandler oAuth2AuthSuccessHandler;
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
+   private static final String[] PERMIT_URLS = {
+           "/",
+           "/login/**",
+           "/oauth2/**",
+           "/swagger-ui/**",
+           "/v3/api-docs/**",
+           "/token",
+//           "/api/v1/users/**"
+   };
 
-                .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/","/login","/oauth2/**","/swagger-ui/**").permitAll()
-                        .requestMatchers("/v3/api-docs/**","/api/public/**").permitAll()
-                        .requestMatchers("/admin/**").hasRole("ADMIN")
-                        .anyRequest().authenticated()
-                )
-                .oauth2Login(oauth2 -> oauth2
-                        .userInfoEndpoint(userInfo -> userInfo
-                                .userService(oAuth2UserService))
-                        .successHandler(oAuth2AuthSuccessHandler) // 로그인 성공 시 JWT 토큰 발급
-                )
-                // UsernamePasswordFilter 앞에서 JWT 필터가 먼저 필터링.
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
-        return http.build();
-    }
+   @Bean
+   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+      http
+              .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+              .csrf(AbstractHttpConfigurer::disable)
+//              .formLogin(AbstractHttpConfigurer::disable)
+              .httpBasic(AbstractHttpConfigurer::disable)
+
+              .sessionManagement(session -> session
+                      .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+              .authorizeHttpRequests(auth -> auth
+                      .requestMatchers(PERMIT_URLS).permitAll()
+                      .anyRequest().authenticated()
+              )
+              .oauth2Login(oauth2 -> oauth2
+                      .userInfoEndpoint(userInfo -> userInfo
+                              .userService(oAuth2UserService))
+                      .successHandler(oAuth2AuthSuccessHandler) // 로그인 성공 시 JWT 토큰 발급
+              )
+              // UsernamePasswordFilter 앞에서 JWT 필터가 먼저 필터링.
+              .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+      return http.build();
+   }
+
+   @Bean
+   public CorsConfigurationSource corsConfigurationSource() {
+      CorsConfiguration cors = new CorsConfiguration();
+      cors.setAllowedOrigins(List.of("http://localhost:3000"));
+      cors.setAllowedHeaders(List.of("Authorization", "Content-Type")); // 실제 사용하는 헤더만 명시적으로 허용
+      cors.setAllowedMethods(
+              Arrays.asList(
+                      HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(),
+                      HttpMethod.PATCH.name(), HttpMethod.DELETE.name(), HttpMethod.OPTIONS.name()));
+      cors.setAllowCredentials(true);
+      UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+      source.registerCorsConfiguration("/**", cors);
+      return source;
+   }
 }

--- a/src/main/java/com/app/pofolit_be/security/auth/OAuth2AuthSuccessHandler.java
+++ b/src/main/java/com/app/pofolit_be/security/auth/OAuth2AuthSuccessHandler.java
@@ -1,8 +1,10 @@
 package com.app.pofolit_be.security.auth;
 
 import com.app.pofolit_be.security.auth.jwt.JwtUtil;
+import com.app.pofolit_be.user.entity.Role;
 import com.app.pofolit_be.user.entity.User;
 import com.app.pofolit_be.user.repository.UserRepository;
+import com.app.pofolit_be.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -31,9 +32,10 @@ public class OAuth2AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHand
 
    private final JwtUtil jwtUtil;
    private final UserRepository userRepository;
-
-   @Value("${app.oauth2.auth.callback:https://localhost:3000/}")
-   private String baseUri = "https://localhost:3000/";
+   @Value("${uri.auth.base}")
+   private String baseUri;
+   @Value("${uri.auth.signup}")
+   private String signup;
 
    /**
     * JWT 만들어서 클라로
@@ -44,38 +46,47 @@ public class OAuth2AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHand
                                        HttpServletResponse response,
                                        Authentication authentication) throws IOException {
       try {
-
-         //[페이로드 추출] OAuth2User로 인증된 사용자 정보 추출
-         //            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-         //            User user = userDetails.getUser();
-         //            log.info("userDetails(principal) : {}", userDetails );
          //[페이로드 추출] OIDC로 인증된 사용자 권한 추출
-         OAuth2User OIDCUserDetails = (OAuth2User) authentication.getPrincipal();
-         log.info("userDetails(principal) : {}", OIDCUserDetails);
+         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+         log.info("OIDCUserDetails (principal) : {}", oAuth2User.getAttributes());
          //[페이로드 추출] { registrationId , providerId(sub) } from OAuth2LoginAuthenticationToken
          OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
          String registrationId = oauthToken.getAuthorizedClientRegistrationId(); //from Authentication's
-         String providerId = OIDCUserDetails.getName(); // from OAuth2User.Principal 안에 name 요소로. /* 전부 표준인 'sub'면 왜꺼내지*/
-
+         String providerId = oAuth2User.getName(); // from OAuth2User.Principal 안에 name 요소로.
+         String nickname = registrationId.equals("google")
+                 ? (String) oAuth2User.getAttributes().get("name")
+                 : (String) oAuth2User.getAttributes().get("nickname");
          User user = userRepository.findByRegistrationIdAndProviderId(registrationId, providerId)
-                 .orElseThrow(() -> new IllegalStateException("oauth2 인증 후 DB에 사용자 찾을 수 없음."));
+//                 .orElseThrow(() -> new IllegalStateException("OAuth2 O || findUser X"));
+                 .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .registrationId(registrationId)
+                            .providerId(providerId)
+                            .email(oAuth2User.getAttribute("email"))
+                            .nickname(nickname)
+                            .role(Role.GUEST)
+                            .build();
+                    return userRepository.save(newUser);
+                 });
 
          // JWT 토큰 생성
          String jwtToken = jwtUtil.generateToken(
                  user.getId(),
                  user.getEmail(),
                  user.getRole().getKey());
-
-         log.info("OAuth2 로그인 성공 - JWT 토큰 발급: userId={}, email={}, provider={}",
-                 user.getId(), user.getEmail(), user.getRegistrationId());
-
-         // to Front URL (토큰 with in header)
-         String targetUrl = UriComponentsBuilder.fromUriString(baseUri)
-                 .queryParam("token", jwtToken)
-                 .queryParam("user", URLEncoder.encode(user.getNickname(), StandardCharsets.UTF_8))
-                 .build()
-                 .toUriString();
-
+         log.info("OAuth2 로그인 성공 : [{}] [{}] [{}] [{}]",
+                 user.getRole().getKey(), user.getRegistrationId(), user.getEmail(), user.getId());
+         // to Front URL with jwt-token
+         String targetUrl;
+         if(user.getRole() == Role.GUEST) {
+            targetUrl = UriComponentsBuilder.fromUriString(signup)
+                    .queryParam("token", jwtToken)
+                    .build().toUriString();
+         } else {
+            targetUrl = UriComponentsBuilder.fromUriString(baseUri)
+                    .queryParam("token", jwtToken)
+                    .build().toUriString();
+         }
          log.info("OAuth2 성공 리다이렉트 URL: {}", targetUrl);
 
          // 리다이렉트 실행
@@ -90,34 +101,7 @@ public class OAuth2AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHand
                  .queryParam("message", URLEncoder.encode("인증 처리 중 오류가 발생했습니다", StandardCharsets.UTF_8))
                  .build()
                  .toUriString();
-
          getRedirectStrategy().sendRedirect(request, response, errorUrl);
       }
-   }
-
-   /**
-    * 리다이렉트 URL 결정 로직
-    * 클라이언트 추가 지원 시 확장용
-    */
-   protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
-      // 요청에서 redirect_uri 파라미터 확인
-      String targetUrl = request.getParameter("redirect_uri");
-
-      if(targetUrl != null && isAuthorizedRedirectUri(targetUrl)) {
-         return targetUrl;
-      }
-
-      return baseUri; // 기본 리다이렉트 URI 사용
-   }
-
-   /**
-    * 허용된 리다이렉트 URI인지 검증
-    * 보안상 허용된 도메인만 리다이렉트 허용
-    */
-   private boolean isAuthorizedRedirectUri(String uri) {
-      // 로컬 개발 환경과 프로덕션 환경 URL 허용
-      return uri.startsWith("http://localhost:3000") ||
-              uri.startsWith("https://pofolit.org") ||
-              uri.startsWith("https://www.pofolit.org");
    }
 }

--- a/src/main/java/com/app/pofolit_be/security/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/app/pofolit_be/security/auth/jwt/JwtFilter.java
@@ -1,7 +1,10 @@
 package com.app.pofolit_be.security.auth.jwt;
 
+import com.app.pofolit_be.user.dto.CustomUserDetails;
+import com.app.pofolit_be.user.dto.OAuth2UserDto;
 import com.app.pofolit_be.user.entity.User;
 import com.app.pofolit_be.user.repository.UserRepository;
+import com.app.pofolit_be.user.service.OAuth2UserService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -41,22 +44,24 @@ public class JwtFilter extends OncePerRequestFilter {
         try {
             // 1. JWT 토큰 추출
             String jwt = getJwtFromRequest(request);
+            log.info("jwt 추출 성공[{}]",jwt);
             // 2. 토큰 유효성 검증
             if (StringUtils.hasText(jwt) && jwtUtil.validateToken(jwt)) {
                 UUID userId = jwtUtil.getUserIdFromToken(jwt);
                 String email = jwtUtil.getEmailFromToken(jwt);
                 String role = jwtUtil.getRoleFromToken(jwt);
-                
+                log.info("[{}][{}][{}]",userId,email,role);
                 // 사용자 정보 조회 (필요시 DB 조회)
                 Optional<User> userOptional = userRepository.findById(userId);
-                
+                log.info("userOptional [{}]",userOptional);
+
                 if (userOptional.isPresent()) {
                     User user = userOptional.get();
                     
                     // Spring Security 인증 객체 생성
                     UsernamePasswordAuthenticationToken authentication = 
                         new UsernamePasswordAuthenticationToken(
-                            user, 
+                            new CustomUserDetails(user),
                             null, 
                             Collections.singleton(new SimpleGrantedAuthority(role))
                         );

--- a/src/main/java/com/app/pofolit_be/user/controller/UserController.java
+++ b/src/main/java/com/app/pofolit_be/user/controller/UserController.java
@@ -1,8 +1,33 @@
 package com.app.pofolit_be.user.controller;
 
+import com.app.pofolit_be.user.dto.CustomUserDetails;
+import com.app.pofolit_be.user.dto.UserDetailsDto;
+import com.app.pofolit_be.user.repository.UserRepository;
+import com.app.pofolit_be.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
 public class UserController {
 
+   private final UserService userService;
+
+
+   @PatchMapping("/me/details")
+   public ResponseEntity<Void> registration(
+           @AuthenticationPrincipal CustomUserDetails userDetails,
+           @RequestBody UserDetailsDto requestDto) {
+      userService.completeRegistration(userDetails.getUser().getId(), requestDto);
+      log.info("권한 변경 성공 [{}]",userDetails.getUser().getRole());
+      return ResponseEntity.ok().build();
+   }
 }

--- a/src/main/java/com/app/pofolit_be/user/dto/CustomUserDetails.java
+++ b/src/main/java/com/app/pofolit_be/user/dto/CustomUserDetails.java
@@ -1,7 +1,9 @@
 package com.app.pofolit_be.user.dto;
 
 import com.app.pofolit_be.user.entity.User;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -18,6 +20,10 @@ public class CustomUserDetails implements OAuth2User {
    private final User user;
    private final Map<String, Object> attributes;
 
+   public CustomUserDetails(User user) {
+      this.user = user;
+      this.attributes = null;
+   }
    @Override
    public Map<String, Object> getAttributes() {
       return attributes;

--- a/src/main/java/com/app/pofolit_be/user/dto/OAuth2UserDto.java
+++ b/src/main/java/com/app/pofolit_be/user/dto/OAuth2UserDto.java
@@ -11,14 +11,14 @@ public record OAuth2UserDto(
         String registrationId
 
 )  {
-   public User toEntity() {
+   public User toEntity(Role role) {
       return User.builder()
               .email(email)
               .nickname(nickname)
               .profileImageUrl(profileImageUrl)
               .registrationId(registrationId)
               .providerId(providerId)
-              .role(Role.USER) // 기본 역할은 USER로 설정
+              .role(role)
               .build();
    }
 }

--- a/src/main/java/com/app/pofolit_be/user/dto/UserDetailsDto.java
+++ b/src/main/java/com/app/pofolit_be/user/dto/UserDetailsDto.java
@@ -1,0 +1,21 @@
+package com.app.pofolit_be.user.dto;
+
+import com.app.pofolit_be.user.entity.Role;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record UserDetailsDto(
+        String aka,
+        @JsonProperty("birthDay")
+        LocalDate birthDay,
+        String domain,
+        String job,
+        List<String> interests,
+        Role role
+)
+{
+
+}
+

--- a/src/main/java/com/app/pofolit_be/user/entity/Role.java
+++ b/src/main/java/com/app/pofolit_be/user/entity/Role.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Role {
-   USER("ROLE_USER","유저"),
-   ADMIN("ROLE_ADMIN","관리자");
+   GUEST("ROLE_GUEST","미가입자"),
+   USER("ROLE_USER","유저");
 
    private final String key;
    private final String title;

--- a/src/main/java/com/app/pofolit_be/user/entity/User.java
+++ b/src/main/java/com/app/pofolit_be/user/entity/User.java
@@ -1,16 +1,25 @@
 package com.app.pofolit_be.user.entity;
 
+import com.app.pofolit_be.user.dto.UserDetailsDto;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Entity(name = "users")
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_user_provider",
+                        columnNames = {"registration_id", "provider_id"}
+                )
+        })
+@Entity
 public class User {
 
    @Id
@@ -22,17 +31,43 @@ public class User {
    @Column(unique = true)
    private String email;
    private String nickname;
-   private String profileImageUrl;
+   private String profileImageUrl; // 카카오:110px*110px
 
    private String providerId;
    private String registrationId;
+   private LocalDate birthDay;
+   private String job;
+   private String domain;
+   @ElementCollection(fetch = FetchType.LAZY)
+   @CollectionTable(name = "user_interests", joinColumns = @JoinColumn(name = "user_id"))
+   @Column(name = "interest")
+   private List<String> interests;
 
    @Enumerated(EnumType.STRING)
    private Role role;
 
-   public User update(String nickname, String profileImageUrl) {
+   @Builder
+   public User(String email, String nickname, String profileImageUrl, String providerId, String registrationId, Role role) {
+      this.email = email;
+      this.nickname = nickname;
+      this.profileImageUrl = profileImageUrl;
+      this.providerId = providerId;
+      this.registrationId = registrationId;
+      this.role = role;
+   }
+
+   public User updateProfile(String nickname, String profileImageUrl) {
       this.nickname = nickname;
       this.profileImageUrl = profileImageUrl;
       return this;
+   }
+
+   public void completeRegistration(UserDetailsDto details) {
+      this.nickname = details.aka();
+      this.birthDay = details.birthDay();
+      this.job = details.job();
+      this.domain = details.domain();
+      this.interests = details.interests();
+      this.role = Role.USER;
    }
 }

--- a/src/main/java/com/app/pofolit_be/user/repository/UserRepository.java
+++ b/src/main/java/com/app/pofolit_be/user/repository/UserRepository.java
@@ -7,5 +7,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
+
    Optional<User> findByRegistrationIdAndProviderId(String registrationId, String providerId);
+   Optional<User> findUserByEmail(String email);
+
 }

--- a/src/main/java/com/app/pofolit_be/user/service/OAuth2UserService.java
+++ b/src/main/java/com/app/pofolit_be/user/service/OAuth2UserService.java
@@ -2,13 +2,12 @@ package com.app.pofolit_be.user.service;
 
 import com.app.pofolit_be.user.dto.CustomUserDetails;
 import com.app.pofolit_be.user.dto.OAuth2UserDto;
-import com.app.pofolit_be.user.entity.Role;
 import com.app.pofolit_be.user.entity.User;
-import com.app.pofolit_be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -18,27 +17,20 @@ import java.util.Map;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class OAuth2UserService extends DefaultOAuth2UserService {
-
-   private final UserRepository userRepository;
-
-
+   private final UserService userService;
 
    @Override
-   @Transactional
    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
       OAuth2User oAuth2User = super.loadUser(userRequest);
       String registrationId = userRequest.getClientRegistration().getRegistrationId();
       Map<String, Object> attributes = oAuth2User.getAttributes();
-
+      OAuth2AccessToken accessToken = userRequest.getAccessToken();
+      log.info("@@@@accessToken{}",accessToken);
       OAuth2UserDto userDto = toDto(registrationId, attributes);
-
-
-      User user = userRepository.findByRegistrationIdAndProviderId(registrationId,userDto.providerId())
-              .map(existingUser -> existingUser.update(userDto.nickname(),userDto.profileImageUrl()))
-              .orElseGet(() -> userRepository.save(userDto.toEntity()));
-      log.info("user save or update success@@@: {}", user);
+      User user = userService.findOrSaveUser(userDto);
       return new CustomUserDetails(user, oAuth2User.getAttributes());
    }
 
@@ -46,21 +38,8 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
       String providerId = (String) attributes.get("sub");
       String email = (String) attributes.get("email");
       String profileImageUrl = (String) attributes.get("picture");
-
-      String nickname = getNickname(attributes) ;
-
-      if(email == null && "kakao".equals(registrationId)){
-         email = providerId + "@" + registrationId + ".com";
-      }
+      String nickname = registrationId.equals("google") ? (String) attributes.get("name") : (String) attributes.get("nickname");
       return new OAuth2UserDto(email, nickname, profileImageUrl, providerId, registrationId);
    }
 
-   private String getNickname(Map<String, Object> attributes) {
-      String nickname = (String) attributes.get("name");
-      if (nickname == null) {
-         // kakao
-         nickname = (String) attributes.get("nickname");
-      }
-      return nickname;
-   }
 }

--- a/src/main/java/com/app/pofolit_be/user/service/UserService.java
+++ b/src/main/java/com/app/pofolit_be/user/service/UserService.java
@@ -1,0 +1,53 @@
+package com.app.pofolit_be.user.service;
+
+import com.app.pofolit_be.user.dto.OAuth2UserDto;
+import com.app.pofolit_be.user.dto.UserDetailsDto;
+import com.app.pofolit_be.user.entity.Role;
+import com.app.pofolit_be.user.entity.User;
+import com.app.pofolit_be.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/*
+ * Facade service
+ *
+ * */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+   private final UserRepository userRepository;
+
+   @Transactional(propagation = Propagation.REQUIRES_NEW)
+   public User findOrSaveUser(OAuth2UserDto userDto) {
+      return userRepository.findByRegistrationIdAndProviderId(userDto.registrationId(), userDto.providerId())
+              .map(existingUser -> {
+                 existingUser.updateProfile(userDto.nickname(), userDto.profileImageUrl());
+                 log.info("정상 로그인 userId{}", existingUser.getId());
+                 return existingUser.updateProfile(userDto.nickname(), userDto.profileImageUrl());
+              })
+              .orElseGet(() -> {
+                 userRepository.findUserByEmail(userDto.email()).ifPresent(existingUserByEmail -> {
+                    log.warn("가입 전적 있음.email{}", userDto.email());
+                    throw new OAuth2AuthorizationException(
+                            new OAuth2Error("ErrorCode:email_in_use", "이미 가입 된 이메일입니다", "uri[]"));
+                 });
+                 log.info("GUEST로 저장.{}", userDto.email());
+                 return userRepository.save(userDto.toEntity(Role.GUEST));
+              });
+   }
+
+   @Transactional
+   public void completeRegistration(UUID userid, UserDetailsDto userDetailDto) {
+      User user = userRepository.findById(userid)
+              .orElseThrow(() -> new IllegalArgumentException("userid 없음"));
+      user.completeRegistration(userDetailDto);
+   }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
-app:
-  oauth2:
-    auth:
-      callback:
+uri:
+  auth:
+    base: "http://localhost:3000"
+    signup: "http://localhost:3000/signup/details"
 server:
   port: 8080
 logging:
@@ -31,7 +31,7 @@ spring:
     password: ${DB_PASSWORD:sa}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate #
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
기존에는 소셜 로그인 시 바로 'USER' 권한을 부여했으나, 서비스에 필요한 추가 정보를 입력받는 회원가입 절차를 구현하기 위해 전체적인 인증 및 사용자 등록 흐름을 개선했습니다.

주요 변경 사항:

- 신규 사용자 등록 절차 구현
  - 최초 소셜 로그인 시 사용자를 'GUEST' 역할로 생성하고, 추가 정보 입력 페이지로 리다이렉트합니다.
  - 사용자가 추가 정보를 입력하면(`PATCH /api/v1/users/me/details`), 역할이 'USER'로 변경되고 서비스의 모든 기능을 사용할 수 있습니다.
  - `User` 엔티티에 직업, 관심 분야 등 추가 정보 필드를 확장했습니다.

- Spring Security 설정 개선
  - 프론트엔드(localhost:3000)에서의 요청을 허용하도록 CORS(Cross-Origin Resource Sharing) 설정을 추가했습니다.
  - 인증 예외 경로를 배열로 관리하여 가독성과 유지보수성을 높였습니다.

- 리팩토링 및 버그 수정
  - `RedisService`의 타임아웃 단위가 `MICROSECONDS`로 잘못 설정된 문제를 `SECONDS`로 수정했습니다.
  - `OAuth2UserService`의 사용자 생성 로직을 `UserService`로 위임하여 역할을 분리했습니다.
  - `application.yml`에서 리다이렉트 URI를 관리하도록 변경하여 구성의 유연성을 확보했습니다.